### PR TITLE
Test optimality

### DIFF
--- a/src/tracesum.jl
+++ b/src/tracesum.jl
@@ -303,13 +303,13 @@ function test_optimality(
     @inbounds for i in 1:m
         # check constraint satisfication O[i]'O[i] = I(r)
         mul!(storage_rr, transpose(O[i]), O[i])
-        storage_rr ≈ I || (return :infeasible, Λ, Matrix{Matrix{T}}(m, m), T(NaN))
+        storage_rr ≈ I || (return :infeasible, Λ, Matrix{Matrix{T}}(undef, m, m), T(NaN))
         # check symmetry of Λi (first order optimality condition)
         δi = check_symmetry(Λ[i])
         if δi > abs(tol)
             @warn "Λ$i not symmetric; norm(Λ - Λ') = $δi; " *
                 "first order optimality not satisfied"
-            return :suboptimal, Λ, Matrix{Matrix{T}}(m, m), T(NaN)
+            return :suboptimal, Λ, Matrix{Matrix{T}}(undef, m, m), T(NaN)
         end
     end
     # certify global optimality

--- a/src/tracesum.jl
+++ b/src/tracesum.jl
@@ -321,7 +321,7 @@ function test_optimality(
             # if eigmin(Λi) < 0, then it cannot be global optimal
             λmin = minimum(eigvals!(Symmetric(copyto!(storage_rr, Λ[i]))))
             if λmin < -abs(tol)
-                return :nonglobal_stationary_point, Λ, Matrix{T}(0, 0), T(NaN)
+                return :nonglobal_stationary_point, Λ, Matrix{T}(undef, 0, 0), T(NaN)
             end
             # update certificate matrix by Won-Zhou-Lange
             copyto!(storage_rr, Λ[i])


### PR DESCRIPTION
The updated test_optimality() function in tracesum.jl has some bugs. Minimal reproducible example:

```
using OTSM, LinearAlgebra
using MATLAB

# Julia wapper for Manopt function maxbet.m
function maxbet_manopt(S::Array{Matrix{Float64}}, r::Integer, init_fun = init_eye)
    m = size(S)[1]
    # initial value
    O_init = init_fun(S, r)
    X_init = Dict{String, Matrix{Float64}}()
    for i in 1:m
        X_init["X" * string(i)] = O_init[i]
    end
    Smat = cat(S)   # convert to a block matrix
    ds   = [size(S[i, i])[1] for i=1:m]  # dimensions of the blocks
    time_manopt = @elapsed begin
        mat"""
        [$X_str] = maxbet($Smat, $(Float64.(ds)), $(Float64(r)), $(X_init));
        """
    end
    Ô_manopt = Vector{Matrix{Float64}}(undef, m)
    for i in 1:m
        Ô_manopt[i] = (length(size(X_str["X1"])) > 1) ? X_str["X" * string(i)] : 
                reshape(X_str["X" * string(i)], length(X_str["X" * string(i)]), 1)
    end
    X_manopt   = cat(Ô_manopt)
    obj_manopt = tr(X_manopt' * Smat * X_manopt)
    Ô_manopt, obj_manopt, time_manopt
end
# data generation
A, maxdiff_optim, maxbet_optim = portwine_data()
m = 4
Smaxdiff = [A[i]'A[j] for i in 1:m, j in 1:m]
OTSM.verify_input_data!(Smaxdiff, 3, true) # set S[i, i] to 0
# model fitting
r = 3
Ô_manopt, obj_manopt, time_manopt = maxbet_manopt(Smaxdiff, r, init_eye)
cert_manopt1      = test_optimality(Ô_manopt, Smaxdiff, method=:wzl)
```

`Matrix{T}(0, 0)` or `Matrix{Matrix{T}}(m, m)` is not supported: `Matrix{T}(undef, 0, 0)` etc works, hence changed lines containing these expressions to use "undef".

