### PR TITLE
add sotsm_pba: projection onto special orthogonal groups

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "OTSM"
 uuid = "673cdf0f-6752-4a08-b918-e94a550f1aff"
 keywords = ["maxbet", "maxdet", "Procrustes", "little  Grothendieck problem"]
 authors = ["Joong-Ho Won <wonj@stats.snu.ac.kr>", "Hua Zhou <huazhou@ucla.edu>"]
-version = "0.0.9"
+version = "0.0.10"
 
 [deps]
 Convex = "f65535da-76fb-5f13-bab9-19810c17039a"

--- a/docs/OTSM.ipynb
+++ b/docs/OTSM.ipynb
@@ -39,14 +39,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Julia Version 1.4.2\n",
-      "Commit 44fa15b150* (2020-05-23 18:35 UTC)\n",
+      "Julia Version 1.5.0\n",
+      "Commit 96786e22cc (2020-08-01 23:44 UTC)\n",
       "Platform Info:\n",
       "  OS: macOS (x86_64-apple-darwin18.7.0)\n",
       "  CPU: Intel(R) Core(TM) i7-6920HQ CPU @ 2.90GHz\n",
       "  WORD_SIZE: 64\n",
       "  LIBM: libopenlibm\n",
-      "  LLVM: libLLVM-8.0.1 (ORCJIT, skylake)\n",
+      "  LLVM: libLLVM-9.0.1 (ORCJIT, skylake)\n",
       "Environment:\n",
       "  JULIA_EDITOR = code\n",
       "  JULIA_NUM_THREADS = 4\n"
@@ -510,12 +510,12 @@
      "text": [
       "iter = 1, obj = 539.8501989834106\n",
       "iter = 2, obj = 542.2346791607897\n",
-      "iter = 3, obj = 542.326755374587\n",
-      "iter = 4, obj = 542.3275270111226\n",
-      "iter = 5, obj = 542.327550329459\n",
-      "iter = 6, obj = 542.3275506362339\n",
-      "iter = 7, obj = 542.3275506383457\n",
-      "iter = 8, obj = 542.3275506383522\n"
+      "iter = 3, obj = 542.3267553745872\n",
+      "iter = 4, obj = 542.3275270111224\n",
+      "iter = 5, obj = 542.3275503294589\n",
+      "iter = 6, obj = 542.3275506362337\n",
+      "iter = 7, obj = 542.3275506383454\n",
+      "iter = 8, obj = 542.3275506383524\n"
      ]
     }
    ],
@@ -803,27 +803,27 @@
      "text": [
       "iter = 1, obj = 769.5257682063867\n",
       "iter = 2, obj = 778.9896186367976\n",
-      "iter = 3, obj = 779.6705236544665\n",
-      "iter = 4, obj = 779.7414861674778\n",
-      "iter = 5, obj = 779.7533232474\n",
-      "iter = 6, obj = 779.756174278359\n",
-      "iter = 7, obj = 779.7569547275209\n",
-      "iter = 8, obj = 779.7571745803215\n",
-      "iter = 9, obj = 779.7572368336034\n",
-      "iter = 10, obj = 779.7572544704886\n",
-      "iter = 11, obj = 779.7572594658141\n",
+      "iter = 3, obj = 779.6705236544664\n",
+      "iter = 4, obj = 779.7414861674775\n",
+      "iter = 5, obj = 779.7533232474001\n",
+      "iter = 6, obj = 779.7561742783591\n",
+      "iter = 7, obj = 779.7569547275212\n",
+      "iter = 8, obj = 779.7571745803211\n",
+      "iter = 9, obj = 779.7572368336032\n",
+      "iter = 10, obj = 779.757254470489\n",
+      "iter = 11, obj = 779.757259465814\n",
       "iter = 12, obj = 779.7572608802018\n",
-      "iter = 13, obj = 779.757261280583\n",
-      "iter = 14, obj = 779.757261393906\n",
+      "iter = 13, obj = 779.7572612805834\n",
+      "iter = 14, obj = 779.7572613939061\n",
       "iter = 15, obj = 779.7572614259773\n",
-      "iter = 16, obj = 779.7572614350538\n",
-      "iter = 17, obj = 779.7572614376222\n",
-      "iter = 18, obj = 779.7572614383489\n",
+      "iter = 16, obj = 779.7572614350536\n",
+      "iter = 17, obj = 779.7572614376224\n",
+      "iter = 18, obj = 779.757261438349\n",
       "iter = 19, obj = 779.7572614385546\n",
-      "iter = 20, obj = 779.7572614386127\n",
-      "iter = 21, obj = 779.7572614386298\n",
-      "iter = 22, obj = 779.7572614386339\n",
-      "iter = 23, obj = 779.7572614386349\n",
+      "iter = 20, obj = 779.7572614386131\n",
+      "iter = 21, obj = 779.7572614386294\n",
+      "iter = 22, obj = 779.7572614386343\n",
+      "iter = 23, obj = 779.7572614386352\n",
       "iter = 24, obj = 779.7572614386353\n",
       "iter = 25, obj = 779.7572614386356\n"
      ]
@@ -863,17 +863,21 @@
   }
  ],
  "metadata": {
+  "@webio": {
+   "lastCommId": null,
+   "lastKernelId": null
+  },
   "hide_input": false,
   "kernelspec": {
-   "display_name": "Julia 1.4.2",
+   "display_name": "Julia 1.5.0",
    "language": "julia",
-   "name": "julia-1.4"
+   "name": "julia-1.5"
   },
   "language_info": {
    "file_extension": ".jl",
    "mimetype": "application/julia",
    "name": "julia",
-   "version": "1.4.2"
+   "version": "1.5.0"
   },
   "toc": {
    "colors": {

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -23,14 +23,14 @@ Use the backspace key to return to the Julia REPL.
 versioninfo()
 ```
 
-    Julia Version 1.4.2
-    Commit 44fa15b150* (2020-05-23 18:35 UTC)
+    Julia Version 1.5.0
+    Commit 96786e22cc (2020-08-01 23:44 UTC)
     Platform Info:
       OS: macOS (x86_64-apple-darwin18.7.0)
       CPU: Intel(R) Core(TM) i7-6920HQ CPU @ 2.90GHz
       WORD_SIZE: 64
       LIBM: libopenlibm
-      LLVM: libLLVM-8.0.1 (ORCJIT, skylake)
+      LLVM: libLLVM-9.0.1 (ORCJIT, skylake)
     Environment:
       JULIA_EDITOR = code
       JULIA_NUM_THREADS = 4
@@ -304,12 +304,12 @@ Proximal block ascent algorithm for finding a rank $r=2$ solution to MAXDIFF.
 
     iter = 1, obj = 539.8501989834106
     iter = 2, obj = 542.2346791607897
-    iter = 3, obj = 542.326755374587
-    iter = 4, obj = 542.3275270111226
-    iter = 5, obj = 542.327550329459
-    iter = 6, obj = 542.3275506362339
-    iter = 7, obj = 542.3275506383457
-    iter = 8, obj = 542.3275506383522
+    iter = 3, obj = 542.3267553745872
+    iter = 4, obj = 542.3275270111224
+    iter = 5, obj = 542.3275503294589
+    iter = 6, obj = 542.3275506362337
+    iter = 7, obj = 542.3275506383454
+    iter = 8, obj = 542.3275506383524
 
 
 The `test_optimality()` function attempts to certify whether a local solution `O::Vector{Matrix}` is a global solution. The first output indicates the solution is `:infeasible`, `:suboptimal`, `:stationary_point`, or `:global_optimal`.
@@ -475,27 +475,27 @@ Proximal block ascent algorithm for finding a rank $r=2$ solution to MAXBET.
 
     iter = 1, obj = 769.5257682063867
     iter = 2, obj = 778.9896186367976
-    iter = 3, obj = 779.6705236544665
-    iter = 4, obj = 779.7414861674778
-    iter = 5, obj = 779.7533232474
-    iter = 6, obj = 779.756174278359
-    iter = 7, obj = 779.7569547275209
-    iter = 8, obj = 779.7571745803215
-    iter = 9, obj = 779.7572368336034
-    iter = 10, obj = 779.7572544704886
-    iter = 11, obj = 779.7572594658141
+    iter = 3, obj = 779.6705236544664
+    iter = 4, obj = 779.7414861674775
+    iter = 5, obj = 779.7533232474001
+    iter = 6, obj = 779.7561742783591
+    iter = 7, obj = 779.7569547275212
+    iter = 8, obj = 779.7571745803211
+    iter = 9, obj = 779.7572368336032
+    iter = 10, obj = 779.757254470489
+    iter = 11, obj = 779.757259465814
     iter = 12, obj = 779.7572608802018
-    iter = 13, obj = 779.757261280583
-    iter = 14, obj = 779.757261393906
+    iter = 13, obj = 779.7572612805834
+    iter = 14, obj = 779.7572613939061
     iter = 15, obj = 779.7572614259773
-    iter = 16, obj = 779.7572614350538
-    iter = 17, obj = 779.7572614376222
-    iter = 18, obj = 779.7572614383489
+    iter = 16, obj = 779.7572614350536
+    iter = 17, obj = 779.7572614376224
+    iter = 18, obj = 779.757261438349
     iter = 19, obj = 779.7572614385546
-    iter = 20, obj = 779.7572614386127
-    iter = 21, obj = 779.7572614386298
-    iter = 22, obj = 779.7572614386339
-    iter = 23, obj = 779.7572614386349
+    iter = 20, obj = 779.7572614386131
+    iter = 21, obj = 779.7572614386294
+    iter = 22, obj = 779.7572614386343
+    iter = 23, obj = 779.7572614386352
     iter = 24, obj = 779.7572614386353
     iter = 25, obj = 779.7572614386356
 

--- a/src/OTSM.jl
+++ b/src/OTSM.jl
@@ -3,7 +3,6 @@ module OTSM
 export init_eye, init_lww1, init_sb, init_tb
 export generate_procrustes_data
 export otsm_pba, otsm_sdp, portwine_data, test_optimality
-export sotsm_pba
 
 include("tracesum.jl")
 include("initialization.jl")

--- a/src/OTSM.jl
+++ b/src/OTSM.jl
@@ -3,6 +3,7 @@ module OTSM
 export init_eye, init_lww1, init_sb, init_tb
 export generate_procrustes_data
 export otsm_pba, otsm_sdp, portwine_data, test_optimality
+export sotsm_pba
 
 include("tracesum.jl")
 include("initialization.jl")

--- a/src/tracesum.jl
+++ b/src/tracesum.jl
@@ -183,6 +183,112 @@ function otsm_pba(
 end
 
 """
+    sotsm_pba(S, r)
+
+Maximize the trace sum `sum_{i,j} trace(Oi' * S[i, j] * Oj) = trace(O' * S * O)` 
+subject to special orthogonality constraint `Oi' * Oi == I(r)` and $det(Oi)==1`
+by a proximal block ascent algorithm. Each of `S[i, j]` for `i < j` is a
+`di x dj` matrix, `S[i, i]` are symmetric, and `S[i, j] = S[j, i]'`. Note 
+`otsm_pba` is mutating in the sense the keyword argument `O=O_init` is updated 
+with the final solution.
+
+# Positional arguments
+- `S       :: Matrix{Matrix}`: `S[i, j]` is a `di x dj` matrix, `S[i, i]` are
+symmetric, and `S[j, i] = S[i, j]'`.
+- `r       :: Integer`       : rank of solution.
+
+# Keyword arguments
+- `αinv    :: Number`: proximal update constant ``1/α```, default is `1e-3`.
+- `maxiter :: Integer`: maximum number of iterations, default is `50000`.
+- `tolfun  :: Number`: tolerance for objective convergence, default is `1e-10`.
+- `tolvar  :: Number`: tolerance for iterate convergence, default is `1e-8`.
+- `verbose :: Bool`  : verbose display, default is `false`.
+- `O       :: Vector{Matrix}`: starting point, default is `init_tb(S, r)`.
+- `log     :: Bool`: record iterate history or not, defaut is `false`.
+
+# Output
+- `O`       : result, `O[i]` has dimension `di x r`.
+- `tracesum`: objective value evaluated at final `O`.
+- `obj`     : final objective value from PBA algorithm, should be same as `tracesum`.
+- `history` : iterate history.
+"""
+function sotsm_pba(
+    S        :: Matrix{Matrix{T}},
+    r        :: Integer;
+    αinv     :: Number  = 1e-3,
+    maxiter  :: Integer = 50000,
+    tolfun   :: Number  = 1e-10,
+    tolvar   :: Number  = 1e-8,
+    verbose  :: Bool    = false,
+    log      :: Bool    = false,
+    O        :: Vector{Matrix{T}} = init_tb(S, r)
+    ) where T <: BlasReal
+    m = size(S, 1)
+    d = [size(S[i, i], 1) for i in 1:m] # (d[i], d[j]) = size(S[i, j])
+	@assert all(d .== r) "all variables must be fully orthogonal."
+    # record iterate history if requested
+    history          = ConvergenceHistory(partial = !log)
+    history[:tolfun] = tolfun
+    history[:tolvar] = tolvar
+    IterativeSolvers.reserve!(T, history, :tracesum, maxiter)
+    IterativeSolvers.reserve!(T, history, :vchange , maxiter)
+    IterativeSolvers.reserve!(Float64, history, :itertime, maxiter)
+    # initial objective value
+    tic     = time()
+    SO      = S * O # SO[i] = sum_{j} S_{ij} O_j
+    obj::T  = dot(O, SO)
+    toc     = time()
+    IterativeSolvers.nextiter!(history)
+    push!(history, :tracesum, obj)
+    push!(history, :itertime, toc - tic)
+    # pre-allocate intermediate arrays
+    ΔO  = [similar(O[i]) for i in 1:m]
+    tmp = [similar(O[i]) for i in 1:m]
+    Λi  = Matrix{T}(undef, r, r) # Lagrange multipliers
+    for iter in 1:maxiter-1
+        IterativeSolvers.nextiter!(history)
+        verbose && println("iter = $iter, obj = $obj")
+        # block update
+        tic = time()
+        @inbounds for i in 1:m
+            # update Oi
+            # tmp[i] = SO[i] + αinv * O[i]
+            BLAS.axpy!(αinv, O[i], copyto!(tmp[i], SO[i]))
+            Fi = svd!(tmp[i]) # tmp[i] overwritten; singular values sorted
+            copyto!(ΔO[i], O[i]) # ΔO[i] <- O[i]
+            mul!(O[i], Fi.U, Fi.Vt) # O[i] <- Fi.U*Fi.Vt; projection onto O(r)
+			if det(O[i]) < 0
+				# modification to projection onto SO(r)
+				# O[i] <- O[i] - 2 * Fi.U[:, end] * Fi.Vt[end, :]
+				@views BLAS.ger!(-2.0, Fi.U[:, r], Fi.Vt[r, :], O[i])
+			end
+            ΔO[i] .= O[i] .- ΔO[i]
+            # update SO[j]
+            for j in 1:m
+                BLAS.gemm!('N', 'N', T(1), S[j, i], ΔO[i], T(1), SO[j])
+            end
+        end
+        objold  = obj
+        obj     = dot(O, SO)
+        toc     = time()
+        vchange = sum(norm, ΔO) / m # mean Frobenius norm of variable change        
+        push!(history, :tracesum,      obj)
+        push!(history, :vchange ,  vchange)
+        push!(history, :itertime, toc - tic)
+        (vchange < tolvar) && 
+        (abs(obj - objold) < tolfun * abs(objold + 1)) &&
+        IterativeSolvers.setconv(history, true) &&
+        break
+    end
+    # fix identifiability and compute final trace sum objective
+    identify!(O)
+    mul!(SO, S, O)
+    tracesum::T = dot(O, SO)
+    log && IterativeSolvers.shrink!(history)
+    O, tracesum, obj, history
+end
+
+"""
     otsm_sdp(S, r)
 
 Maximize the trace sum `sum_{i,j} trace(Oi' * S[i, j] * Oj)` subject to the

--- a/src/tracesum.jl
+++ b/src/tracesum.jl
@@ -161,17 +161,18 @@ function otsm_pba(
             mul!(O[i], Fi.U, Fi.Vt)
 			if soconstr && det(O[i]) < 0
 				# modification to projection onto SO(r)
-				# O[i] <- O[i] - 2 * Fi.U[:, end] * Fi.Vt[end, :]
+                # O[i] <- O[i] - 2 * Fi.U[:, end] * Fi.Vt[end, :]
+                # <https://www.manopt.org/manifold_documentation_rotations.html>
 				@views BLAS.ger!(T(-2), Fi.U[:, r], Fi.Vt[r, :], O[i])
-			end            
+			end
             ΔO[i] .= O[i] .- ΔO[i]
-            # update SO[j] for j > i
-            for j in (i+1):m
+            # update SO[j]
+            for j in 1:m
                 BLAS.gemm!('N', 'N', T(1), S[j, i], ΔO[i], T(1), SO[j])
             end
         end
         objold  = obj
-        obj     = dot(O, mul!(SO, S, O))
+        obj     = dot(O, SO)
         toc     = time()
         vchange = sum(norm, ΔO) / m # mean Frobenius norm of variable change        
         push!(history, :tracesum,       obj)


### PR DESCRIPTION
A modified block relaxation algorithm that projects a matrix onto SO(r) instead of a Stiefel manifold is implemented. This function sotsm_pba() is useful for cryo-EM reconstruction and other Procrustes methods that restrict the orthogonal matrices to be rotation matrices (determinant == 1).